### PR TITLE
[WIP] support odpic 3.x

### DIFF
--- a/src/Database/Dpi.hs
+++ b/src/Database/Dpi.hs
@@ -1068,11 +1068,6 @@ isLobResourceOpen (cxt,p) = libLobGetIsResourceOpen p & outValue cxt peekBool
 copyLob :: PtrLob -> IO PtrLob
 copyLob p@(cxt,_)= (cxt,) <$> runVar libLobCopy p
 
--- | Flush or write all buffers for this LOB to the server.
-{-# INLINE flushLob #-}
-flushLob :: PtrLob -> IO Bool
-flushLob = runBool libLobFlushBuffer
-
 -- | Returns the size of the buffer needed to hold the number of characters specified for a buffer of the type
 -- associated with the LOB. If the LOB does not refer to a character LOB the value is returned unchanged.
 {-# INLINE getLobBufferSize #-}

--- a/src/Database/Dpi/Internal.chs
+++ b/src/Database/Dpi/Internal.chs
@@ -2113,7 +2113,11 @@ libSubscrRelease     = {#call Subscr_release      #}
 {-# INLINE libVarSetNumElementsInArray #-}
 libVarAddRef                = {#call Var_addRef                #}
 libVarCopyData              = {#call Var_copyData              #}
+#if DPI_MAJOR_VERSION >= 3
+libVarGetData               = {#call dpiVar_getReturnedData    #}
+#else
 libVarGetData               = {#call Var_getData               #}
+#endif
 libVarGetNumElementsInArray = {#call Var_getNumElementsInArray #}
 libVarGetSizeInBytes        = {#call Var_getSizeInBytes        #}
 libVarRelease               = {#call Var_release               #}

--- a/src/Database/Dpi/Internal.chs
+++ b/src/Database/Dpi/Internal.chs
@@ -1849,7 +1849,6 @@ libEnqOptionsSetVisibility     = {#call EnqOptions_setVisibility     #}
 {-# INLINE libLobClose                   #-}
 {-# INLINE libLobCloseResource           #-}
 {-# INLINE libLobCopy                    #-}
-{-# INLINE libLobFlushBuffer             #-}
 {-# INLINE libLobGetBufferSize           #-}
 {-# INLINE libLobGetChunkSize            #-}
 {-# INLINE libLobGetDirectoryAndFileName #-}
@@ -1867,7 +1866,6 @@ libLobAddRef                  = {#call Lob_addRef                  #}
 libLobClose                   = {#call Lob_close                   #}
 libLobCloseResource           = {#call Lob_closeResource           #}
 libLobCopy                    = {#call Lob_copy                    #}
-libLobFlushBuffer             = {#call Lob_flushBuffer             #}
 libLobGetBufferSize           = {#call Lob_getBufferSize           #}
 libLobGetChunkSize            = {#call Lob_getChunkSize            #}
 libLobGetDirectoryAndFileName = {#call Lob_getDirectoryAndFileName #}

--- a/src/Database/Dpi/Internal.chs
+++ b/src/Database/Dpi/Internal.chs
@@ -1702,7 +1702,11 @@ libConnGetStmtCacheSize    = {#call Conn_getStmtCacheSize    #}
 libConnNewDeqOptions       = {#call Conn_newDeqOptions       #}
 libConnNewEnqOptions       = {#call Conn_newEnqOptions       #}
 libConnNewMsgProps         = {#call Conn_newMsgProps         #}
+#if DPI_MAJOR_VERSION >= 3
+libConnNewSubscription     = {#call dpiConn_subscribe        #}
+#else
 libConnNewSubscription     = {#call Conn_newSubscription     #}
+#endif
 libConnNewTempLob          = {#call Conn_newTempLob          #}
 libConnNewVar              = {#call Conn_newVar              #}
 libConnPing                = {#call Conn_ping                #}
@@ -2084,10 +2088,15 @@ libRowidRelease        = {#call Rowid_release        #}
 {-# INLINE libSubscrClose       #-}
 {-# INLINE libSubscrPrepareStmt #-}
 {-# INLINE libSubscrRelease     #-}
-libSubscrAddRef      = {#call Subscr_addRef      #}
-libSubscrClose       = {#call Subscr_close       #}
-libSubscrPrepareStmt = {#call Subscr_prepareStmt #}
-libSubscrRelease     = {#call Subscr_release     #}
+libSubscrAddRef      = {#call Subscr_addRef       #}
+#if DPI_MAJOR_VERSION >= 3
+libSubscrClose       = {#call dpiConn_unsubscribe #}
+#else
+libSubscrClose       = {#call Subscr_close        #}
+#endif
+
+libSubscrPrepareStmt = {#call Subscr_prepareStmt  #}
+libSubscrRelease     = {#call Subscr_release      #}
 
 -- Var
 {-# INLINE libVarAddRef                #-}

--- a/src/Database/Dpi/Internal.chs
+++ b/src/Database/Dpi/Internal.chs
@@ -24,30 +24,535 @@ success = {#const DPI_SUCCESS #}
 defaultDriverName :: ByteString
 defaultDriverName = {#const DPI_DEFAULT_DRIVER_NAME #}
 
--- Enum
+data Auth
+
+# if DPI_MAJOR_VERSION >= 3
+data AuthMode
+  = ModeAuthDefault | ModeAuthSysdba | ModeAuthSysoper
+  | ModeAuthPrelim | ModeAuthSysasm | ModeAuthSysBkp
+  | ModeAuthSysDgd | ModeAuthSyskmt | ModeAuthSysrac
+  deriving (Eq, Show)
+
+instance Enum AuthMode where
+  toEnum {#const DPI_MODE_AUTH_DEFAULT #} = ModeAuthDefault
+  toEnum {#const DPI_MODE_AUTH_SYSDBA #} = ModeAuthSysdba
+  toEnum {#const DPI_MODE_AUTH_SYSOPER #} = ModeAuthSysoper
+  toEnum {#const DPI_MODE_AUTH_PRELIM #} = ModeAuthPrelim
+  toEnum {#const DPI_MODE_AUTH_SYSASM #} = ModeAuthSysasm
+  toEnum {#const DPI_MODE_AUTH_SYSBKP #} = ModeAuthSysBkp
+  toEnum {#const DPI_MODE_AUTH_SYSDGD #} = ModeAuthSysDgd
+  toEnum {#const DPI_MODE_AUTH_SYSKMT #} = ModeAuthSyskmt
+  toEnum {#const DPI_MODE_AUTH_SYSRAC #} = ModeAuthSysrac
+  toEnum _ = error "Value invalid"
+  fromEnum ModeAuthDefault = {#const DPI_MODE_AUTH_DEFAULT #}
+  fromEnum ModeAuthSysdba = {#const DPI_MODE_AUTH_SYSDBA #}
+  fromEnum ModeAuthSysoper = {#const DPI_MODE_AUTH_SYSOPER #}
+  fromEnum ModeAuthPrelim = {#const DPI_MODE_AUTH_PRELIM #}
+  fromEnum ModeAuthSysasm = {#const DPI_MODE_AUTH_SYSASM #}
+  fromEnum ModeAuthSysBkp = {#const DPI_MODE_AUTH_SYSBKP #}
+  fromEnum ModeAuthSysDgd = {#const DPI_MODE_AUTH_SYSDGD #}
+  fromEnum ModeAuthSyskmt = {#const DPI_MODE_AUTH_SYSKMT #}
+  fromEnum ModeAuthSysrac = {#const DPI_MODE_AUTH_SYSRAC #}
+#else
 {#enum AuthMode            as ^ {underscoreToCase} deriving (Eq, Show) #}
+#endif
+
+#if DPI_MAJOR_VERSION >= 3
+data ConnCloseMode
+  = ModeConnCloseDefault | ModeConnCloseDrop | ModeConnCloseRetag
+  deriving (Eq, Show)
+
+instance Enum ConnCloseMode where
+  toEnum {#const DPI_MODE_CONN_CLOSE_DEFAULT #} = ModeConnCloseDefault
+  toEnum {#const DPI_MODE_CONN_CLOSE_DROP #} = ModeConnCloseDrop
+  toEnum {#const DPI_MODE_CONN_CLOSE_RETAG #} = ModeConnCloseRetag
+  toEnum _ = error "Value invalid"
+  fromEnum ModeConnCloseDefault = {#const DPI_MODE_CONN_CLOSE_DEFAULT #}
+  fromEnum ModeConnCloseDrop = {#const DPI_MODE_CONN_CLOSE_DROP #}
+  fromEnum ModeConnCloseRetag = {#const DPI_MODE_CONN_CLOSE_RETAG #}
+#else
 {#enum ConnCloseMode       as ^ {underscoreToCase} deriving (Eq, Show) #}
+#endif
+
+#if DPI_MAJOR_VERSION >= 3
+data CreateMode
+  = ModeCreateDefault | ModeCreateThreaded | ModeCreateEvents
+  deriving (Eq, Show)
+
+instance Enum CreateMode where
+  toEnum {#const DPI_MODE_CREATE_DEFAULT #} = ModeCreateDefault
+  toEnum {#const DPI_MODE_CREATE_THREADED #} = ModeCreateThreaded
+  toEnum {#const DPI_MODE_CREATE_EVENTS #} = ModeCreateEvents
+  toEnum _ = error "Value invalid"
+  fromEnum ModeCreateDefault = {#const DPI_MODE_CREATE_DEFAULT #}
+  fromEnum ModeCreateThreaded = {#const DPI_MODE_CREATE_THREADED #}
+  fromEnum ModeCreateEvents = {#const DPI_MODE_CREATE_EVENTS #}
+#else
 {#enum CreateMode          as ^ {underscoreToCase} deriving (Eq, Show) #}
+#endif
+
+#if DPI_MAJOR_VERSION >= 3
+data DeqMode
+  = ModeDeqBrowse | ModeDeqLocked | ModeDeqRemove | ModeDeqRemoveNoData
+  deriving(Eq, Show)
+
+instance Enum DeqMode where
+  toEnum {#const DPI_MODE_DEQ_BROWSE #} = ModeDeqBrowse
+  toEnum {#const DPI_MODE_DEQ_LOCKED #} = ModeDeqLocked
+  toEnum {#const DPI_MODE_DEQ_REMOVE #} = ModeDeqRemove
+  toEnum {#const DPI_MODE_DEQ_REMOVE_NO_DATA #} = ModeDeqRemoveNoData
+  toEnum _ = error "Value invalid"
+  fromEnum ModeDeqBrowse = {#const DPI_MODE_DEQ_BROWSE #}
+  fromEnum ModeDeqLocked = {#const DPI_MODE_DEQ_LOCKED #}
+  fromEnum ModeDeqRemove = {#const DPI_MODE_DEQ_REMOVE #}
+  fromEnum ModeDeqRemoveNoData = {#const DPI_MODE_DEQ_REMOVE_NO_DATA #}
+#else
 {#enum DeqMode             as ^ {underscoreToCase} deriving (Eq, Show) #}
+#endif
+
+#if DPI_MAJOR_VERSION >= 3
+data DeqNavigation
+  = DeqNavFirstMsg | DeqNavNextTransaction | DeqNavNextMsg
+  deriving(Eq, Show)
+
+instance Enum DeqNavigation where
+  toEnum {#const DPI_DEQ_NAV_FIRST_MSG #} = DeqNavFirstMsg
+  toEnum {#const DPI_DEQ_NAV_NEXT_TRANSACTION #} = DeqNavNextTransaction
+  toEnum {#const DPI_DEQ_NAV_NEXT_MSG #} = DeqNavNextMsg
+  toEnum _ = error "Value invalid"
+  fromEnum DeqNavFirstMsg = {#const DPI_DEQ_NAV_FIRST_MSG #}
+  fromEnum DeqNavNextTransaction = {#const DPI_DEQ_NAV_NEXT_TRANSACTION #}
+  fromEnum DeqNavNextMsg = {#const DPI_DEQ_NAV_NEXT_MSG #}
+#else
 {#enum DeqNavigation       as ^ {underscoreToCase} deriving (Eq, Show) #}
+#endif
+
+#if DPI_MAJOR_VERSION >= 3
+data EventType
+  = EventNone | EventStartup | EventShutdown | EventShutdownAny
+  | EventDropDb | EventDereg | EventObjchange | EventQuerychange | EventAq
+  deriving(Eq, Show)
+
+instance Enum EventType where
+  toEnum {#const DPI_EVENT_NONE #} = EventNone
+  toEnum {#const DPI_EVENT_STARTUP #} = EventStartup
+  toEnum {#const DPI_EVENT_SHUTDOWN #} = EventShutdown
+  toEnum {#const DPI_EVENT_SHUTDOWN_ANY #} = EventShutdownAny
+  toEnum {#const DPI_EVENT_DROP_DB #} = EventDropDb
+  toEnum {#const DPI_EVENT_DEREG #} = EventDereg
+  toEnum {#const DPI_EVENT_OBJCHANGE #} = EventObjchange
+  toEnum {#const DPI_EVENT_QUERYCHANGE #} = EventQuerychange
+  toEnum {#const DPI_EVENT_AQ #} = EventAq
+  toEnum _ = error "Value invalid"
+  fromEnum EventNone = {#const DPI_EVENT_NONE #}
+  fromEnum EventStartup = {#const DPI_EVENT_STARTUP #}
+  fromEnum EventShutdown = {#const DPI_EVENT_SHUTDOWN #}
+  fromEnum EventShutdownAny = {#const DPI_EVENT_SHUTDOWN_ANY #}
+  fromEnum EventDropDb = {#const DPI_EVENT_DROP_DB #}
+  fromEnum EventDereg = {#const DPI_EVENT_DEREG #}
+  fromEnum EventObjchange = {#const DPI_EVENT_OBJCHANGE #}
+  fromEnum EventQuerychange = {#const DPI_EVENT_QUERYCHANGE #}
+  fromEnum EventAq = {#const DPI_EVENT_AQ #}
+#else
 {#enum EventType           as ^ {underscoreToCase} deriving (Eq, Show) #}
+#endif
+
+#if DPI_MAJOR_VERSION >= 3
+data ExecMode
+  = ModeExecDefault | ModeExecDescribeOnly | ModeExecCommitOnSuccess
+  | ModeExecBatchErrors | ModeExecParseOnly | ModeExecArrayDmlRowcounts
+  deriving(Eq, Show)
+
+instance Enum ExecMode where
+  toEnum {#const DPI_MODE_EXEC_DEFAULT #} = ModeExecDefault
+  toEnum {#const DPI_MODE_EXEC_DESCRIBE_ONLY #} = ModeExecDescribeOnly
+  toEnum {#const DPI_MODE_EXEC_COMMIT_ON_SUCCESS #} = ModeExecCommitOnSuccess
+  toEnum {#const DPI_MODE_EXEC_BATCH_ERRORS #} = ModeExecBatchErrors
+  toEnum {#const DPI_MODE_EXEC_PARSE_ONLY #} = ModeExecParseOnly
+  toEnum {#const DPI_MODE_EXEC_ARRAY_DML_ROWCOUNTS #} = ModeExecArrayDmlRowcounts
+  toEnum _ = error "Value invalid"
+  fromEnum ModeExecDefault = {#const DPI_MODE_EXEC_DEFAULT #}
+  fromEnum ModeExecDescribeOnly = {#const DPI_MODE_EXEC_DESCRIBE_ONLY #}
+  fromEnum ModeExecCommitOnSuccess = {#const DPI_MODE_EXEC_COMMIT_ON_SUCCESS #}
+  fromEnum ModeExecBatchErrors = {#const DPI_MODE_EXEC_BATCH_ERRORS #}
+  fromEnum ModeExecParseOnly = {#const DPI_MODE_EXEC_PARSE_ONLY #}
+  fromEnum ModeExecArrayDmlRowcounts = {#const DPI_MODE_EXEC_ARRAY_DML_ROWCOUNTS #}
+#else
 {#enum ExecMode            as ^ {underscoreToCase} deriving (Eq, Show) #}
+#endif
+
+#if DPI_MAJOR_VERSION >= 3
+data FetchMode
+  = ModeFetchNext | ModeFetchFirst | ModeFetchLast
+  | ModeFetchPrior | ModeFetchAbsolute | ModeFetchRelative
+  deriving(Eq, Show)
+
+instance Enum FetchMode where
+  toEnum {#const DPI_MODE_FETCH_NEXT #} = ModeFetchNext
+  toEnum {#const DPI_MODE_FETCH_FIRST #} = ModeFetchFirst
+  toEnum {#const DPI_MODE_FETCH_LAST #} = ModeFetchLast
+  toEnum {#const DPI_MODE_FETCH_PRIOR #} = ModeFetchPrior
+  toEnum {#const DPI_MODE_FETCH_ABSOLUTE #} = ModeFetchAbsolute
+  toEnum {#const DPI_MODE_FETCH_RELATIVE #} = ModeFetchRelative
+  toEnum _ = error "Value invalid"
+  fromEnum ModeFetchNext = {#const DPI_MODE_FETCH_NEXT #}
+  fromEnum ModeFetchFirst = {#const DPI_MODE_FETCH_FIRST #}
+  fromEnum ModeFetchLast = {#const DPI_MODE_FETCH_LAST #}
+  fromEnum ModeFetchPrior = {#const DPI_MODE_FETCH_PRIOR #}
+  fromEnum ModeFetchAbsolute = {#const DPI_MODE_FETCH_ABSOLUTE #}
+  fromEnum ModeFetchRelative = {#const DPI_MODE_FETCH_RELATIVE #}
+#else
 {#enum FetchMode           as ^ {underscoreToCase} deriving (Eq, Show) #}
+#endif
+
+#if DPI_MAJOR_VERSION >= 3
+data MessageDeliveryMode
+  = ModeMsgPersistent | ModeMsgBuffered | ModeMsgPersistentOrBuffered
+  deriving(Eq, Show)
+
+instance Enum MessageDeliveryMode where
+  toEnum {#const DPI_MODE_MSG_PERSISTENT #} = ModeMsgPersistent
+  toEnum {#const DPI_MODE_MSG_BUFFERED #} = ModeMsgBuffered
+  toEnum {#const DPI_MODE_MSG_PERSISTENT_OR_BUFFERED #} = ModeMsgPersistentOrBuffered
+  toEnum _ = error "Value invalid"
+  fromEnum ModeMsgPersistent = {#const DPI_MODE_MSG_PERSISTENT #}
+  fromEnum ModeMsgBuffered = {#const DPI_MODE_MSG_BUFFERED #}
+  fromEnum ModeMsgPersistentOrBuffered = {#const DPI_MODE_MSG_PERSISTENT_OR_BUFFERED #}
+#else
 {#enum MessageDeliveryMode as ^ {underscoreToCase} deriving (Eq, Show) #}
+#endif
+
+#if DPI_MAJOR_VERSION >=3
+data MessageState
+  = MsgStateReady | MsgStateWaiting | MsgStateProcessed | MsgStateExpired
+  deriving(Eq, Show)
+
+instance Enum MessageState where
+  toEnum {#const DPI_MSG_STATE_READY #} = MsgStateReady
+  toEnum {#const DPI_MSG_STATE_WAITING #} = MsgStateWaiting
+  toEnum {#const DPI_MSG_STATE_PROCESSED #} = MsgStateProcessed
+  toEnum {#const DPI_MSG_STATE_EXPIRED #} = MsgStateExpired
+  toEnum _ = error "Value invalid"
+  fromEnum MsgStateReady = {#const DPI_MSG_STATE_READY #}
+  fromEnum MsgStateWaiting = {#const DPI_MSG_STATE_WAITING #}
+  fromEnum MsgStateProcessed = {#const DPI_MSG_STATE_PROCESSED #}
+  fromEnum MsgStateExpired = {#const DPI_MSG_STATE_EXPIRED #}
+#else
 {#enum MessageState        as ^ {underscoreToCase} deriving (Eq, Show) #}
+#endif
+
+#if DPI_MAJOR_VERSION >= 3
+data NativeTypeNum
+  = NativeTypeInt64
+  | NativeTypeUint64
+  | NativeTypeFloat
+  | NativeTypeDouble
+  | NativeTypeBytes
+  | NativeTypeTimestamp
+  | NativeTypeIntervalDs
+  | NativeTypeIntervalYm
+  | NativeTypeLob
+  | NativeTypeObject
+  | NativeTypeStmt
+  | NativeTypeBoolean
+  | NativeTypeRowid
+  deriving(Eq, Show)
+
+instance Enum NativeTypeNum where
+  toEnum {#const DPI_NATIVE_TYPE_INT64 #} = NativeTypeInt64
+  toEnum {#const DPI_NATIVE_TYPE_UINT64 #} = NativeTypeUint64
+  toEnum {#const DPI_NATIVE_TYPE_FLOAT #} = NativeTypeFloat
+  toEnum {#const DPI_NATIVE_TYPE_DOUBLE #} = NativeTypeDouble
+  toEnum {#const DPI_NATIVE_TYPE_BYTES #} = NativeTypeBytes
+  toEnum {#const DPI_NATIVE_TYPE_TIMESTAMP #} = NativeTypeTimestamp
+  toEnum {#const DPI_NATIVE_TYPE_INTERVAL_DS #} = NativeTypeIntervalDs
+  toEnum {#const DPI_NATIVE_TYPE_INTERVAL_YM #} = NativeTypeIntervalYm
+  toEnum {#const DPI_NATIVE_TYPE_LOB #} = NativeTypeLob
+  toEnum {#const DPI_NATIVE_TYPE_OBJECT #} = NativeTypeObject
+  toEnum {#const DPI_NATIVE_TYPE_STMT #} = NativeTypeStmt
+  toEnum {#const DPI_NATIVE_TYPE_BOOLEAN #} = NativeTypeBoolean
+  toEnum {#const DPI_NATIVE_TYPE_ROWID #} = NativeTypeRowid
+  toEnum _ = error "Value invalid"
+  fromEnum NativeTypeInt64 = {#const DPI_NATIVE_TYPE_INT64 #}
+  fromEnum NativeTypeUint64 = {#const DPI_NATIVE_TYPE_UINT64 #}
+  fromEnum NativeTypeFloat = {#const DPI_NATIVE_TYPE_FLOAT #}
+  fromEnum NativeTypeDouble = {#const DPI_NATIVE_TYPE_DOUBLE #}
+  fromEnum NativeTypeBytes = {#const DPI_NATIVE_TYPE_BYTES #}
+  fromEnum NativeTypeTimestamp = {#const DPI_NATIVE_TYPE_TIMESTAMP #}
+  fromEnum NativeTypeIntervalDs = {#const DPI_NATIVE_TYPE_INTERVAL_DS #}
+  fromEnum NativeTypeIntervalYm = {#const DPI_NATIVE_TYPE_INTERVAL_YM #}
+  fromEnum NativeTypeLob = {#const DPI_NATIVE_TYPE_LOB #}
+  fromEnum NativeTypeObject = {#const DPI_NATIVE_TYPE_OBJECT #}
+  fromEnum NativeTypeStmt = {#const DPI_NATIVE_TYPE_STMT #}
+  fromEnum NativeTypeBoolean = {#const DPI_NATIVE_TYPE_BOOLEAN #}
+  fromEnum NativeTypeRowid = {#const DPI_NATIVE_TYPE_ROWID #}
+#else
 {#enum NativeTypeNum       as ^ {underscoreToCase} deriving (Eq, Show) #}
+#endif
+
+
+#if DPI_MAJOR_VERSION >= 3
+data OpCode
+  = OpcodeAllOps
+  | OpcodeAllRows
+  | OpcodeInsert
+  | OpcodeUpdate
+  | OpcodeDelete
+  | OpcodeAlter
+  | OpcodeDrop
+  | OpcodeUnknown
+  deriving(Eq, Show)
+
+instance Enum OpCode where
+  toEnum {#const DPI_OPCODE_ALL_OPS #} = OpcodeAllOps
+  toEnum {#const DPI_OPCODE_ALL_ROWS #} = OpcodeAllRows
+  toEnum {#const DPI_OPCODE_INSERT #} = OpcodeInsert
+  toEnum {#const DPI_OPCODE_UPDATE #} = OpcodeUpdate
+  toEnum {#const DPI_OPCODE_DELETE #} = OpcodeDelete
+  toEnum {#const DPI_OPCODE_ALTER #} = OpcodeAlter
+  toEnum {#const DPI_OPCODE_DROP #} = OpcodeDrop
+  toEnum {#const DPI_OPCODE_UNKNOWN #} = OpcodeUnknown
+  toEnum _ = error "Value invalid"
+  fromEnum OpcodeAllOps = {#const DPI_OPCODE_ALL_OPS #}
+  fromEnum OpcodeAllRows = {#const DPI_OPCODE_ALL_ROWS #}
+  fromEnum OpcodeInsert = {#const DPI_OPCODE_INSERT #}
+  fromEnum OpcodeUpdate = {#const DPI_OPCODE_UPDATE #}
+  fromEnum OpcodeDelete = {#const DPI_OPCODE_DELETE #}
+  fromEnum OpcodeAlter = {#const DPI_OPCODE_ALTER #}
+  fromEnum OpcodeDrop = {#const DPI_OPCODE_DROP #}
+  fromEnum OpcodeUnknown = {#const DPI_OPCODE_UNKNOWN #}
+
+#else
 {#enum OpCode              as ^ {underscoreToCase} deriving (Eq, Show) #}
+#endif
+
+#if DPI_MAJOR_VERSION >= 3
+data OracleTypeNum
+  = OracleTypeNone
+  | OracleTypeVarchar
+  | OracleTypeNvarchar
+  | OracleTypeChar
+  | OracleTypeNchar
+  | OracleTypeRowid
+  | OracleTypeRaw
+  | OracleTypeNativeFloat
+  | OracleTypeNativeDouble
+  | OracleTypeNativeInt
+  | OracleTypeNumber
+  | OracleTypeDate
+  | OracleTypeTimestamp
+  | OracleTypeTimestampTz
+  | OracleTypeTimestampLtz
+  | OracleTypeIntervalDs
+  | OracleTypeIntervalYm
+  | OracleTypeClob
+  | OracleTypeNclob
+  | OracleTypeBlob
+  | OracleTypeBfile
+  | OracleTypeStmt
+  | OracleTypeBoolean
+  | OracleTypeObject
+  | OracleTypeLongVarchar
+  | OracleTypeLongRaw
+  | OracleTypeNativeUint
+  deriving(Eq, Show)
+  --TODO: OracleTypeMax
+
+instance Enum OracleTypeNum where
+  toEnum {#const DPI_ORACLE_TYPE_NONE #} = OracleTypeNone
+  toEnum {#const DPI_ORACLE_TYPE_VARCHAR #} = OracleTypeVarchar
+  toEnum {#const DPI_ORACLE_TYPE_NVARCHAR #} = OracleTypeNvarchar
+  toEnum {#const DPI_ORACLE_TYPE_CHAR #} = OracleTypeChar
+  toEnum {#const DPI_ORACLE_TYPE_NCHAR #} = OracleTypeNchar
+  toEnum {#const DPI_ORACLE_TYPE_ROWID #} = OracleTypeRowid
+  toEnum {#const DPI_ORACLE_TYPE_RAW #} = OracleTypeRaw
+  toEnum {#const DPI_ORACLE_TYPE_NATIVE_FLOAT #} = OracleTypeNativeFloat
+  toEnum {#const DPI_ORACLE_TYPE_NATIVE_DOUBLE #} = OracleTypeNativeDouble
+  toEnum {#const DPI_ORACLE_TYPE_NATIVE_INT #} = OracleTypeNativeInt
+  toEnum {#const DPI_ORACLE_TYPE_NUMBER #} = OracleTypeNumber
+  toEnum {#const DPI_ORACLE_TYPE_DATE #} = OracleTypeDate
+  toEnum {#const DPI_ORACLE_TYPE_TIMESTAMP #} = OracleTypeTimestamp
+  toEnum {#const DPI_ORACLE_TYPE_TIMESTAMP_TZ #} = OracleTypeTimestampTz
+  toEnum {#const DPI_ORACLE_TYPE_TIMESTAMP_LTZ #} = OracleTypeTimestampLtz
+  toEnum {#const DPI_ORACLE_TYPE_INTERVAL_DS #} = OracleTypeIntervalDs
+  toEnum {#const DPI_ORACLE_TYPE_INTERVAL_YM #} = OracleTypeIntervalYm
+  toEnum {#const DPI_ORACLE_TYPE_CLOB #} = OracleTypeClob
+  toEnum {#const DPI_ORACLE_TYPE_NCLOB #} = OracleTypeNclob
+  toEnum {#const DPI_ORACLE_TYPE_BLOB #} = OracleTypeBlob
+  toEnum {#const DPI_ORACLE_TYPE_BFILE #} = OracleTypeBfile
+  toEnum {#const DPI_ORACLE_TYPE_STMT #} = OracleTypeStmt
+  toEnum {#const DPI_ORACLE_TYPE_BOOLEAN #} = OracleTypeBoolean
+  toEnum {#const DPI_ORACLE_TYPE_OBJECT #} = OracleTypeObject
+  toEnum {#const DPI_ORACLE_TYPE_LONG_VARCHAR #} = OracleTypeLongVarchar
+  toEnum {#const DPI_ORACLE_TYPE_LONG_RAW #} = OracleTypeLongRaw
+  toEnum {#const DPI_ORACLE_TYPE_NATIVE_UINT #} = OracleTypeNativeUint
+  toEnum _ = error "Value invalid"
+  fromEnum OracleTypeNone = {#const DPI_ORACLE_TYPE_NONE #}
+  fromEnum OracleTypeVarchar = {#const DPI_ORACLE_TYPE_VARCHAR #}
+  fromEnum OracleTypeNvarchar = {#const DPI_ORACLE_TYPE_NVARCHAR #}
+  fromEnum OracleTypeChar = {#const DPI_ORACLE_TYPE_CHAR #}
+  fromEnum OracleTypeNchar = {#const DPI_ORACLE_TYPE_NCHAR #}
+  fromEnum OracleTypeRowid = {#const DPI_ORACLE_TYPE_ROWID #}
+  fromEnum OracleTypeRaw = {#const DPI_ORACLE_TYPE_RAW #}
+  fromEnum OracleTypeNativeFloat = {#const DPI_ORACLE_TYPE_NATIVE_FLOAT #}
+  fromEnum OracleTypeNativeDouble = {#const DPI_ORACLE_TYPE_NATIVE_DOUBLE #}
+  fromEnum OracleTypeNativeInt = {#const DPI_ORACLE_TYPE_NATIVE_INT #}
+  fromEnum OracleTypeNumber = {#const DPI_ORACLE_TYPE_NUMBER #}
+  fromEnum OracleTypeDate = {#const DPI_ORACLE_TYPE_DATE #}
+  fromEnum OracleTypeTimestamp = {#const DPI_ORACLE_TYPE_TIMESTAMP #}
+  fromEnum OracleTypeTimestampTz = {#const DPI_ORACLE_TYPE_TIMESTAMP_TZ #}
+  fromEnum OracleTypeTimestampLtz = {#const DPI_ORACLE_TYPE_TIMESTAMP_LTZ #}
+  fromEnum OracleTypeIntervalDs = {#const DPI_ORACLE_TYPE_INTERVAL_DS #}
+  fromEnum OracleTypeIntervalYm = {#const DPI_ORACLE_TYPE_INTERVAL_YM #}
+  fromEnum OracleTypeClob = {#const DPI_ORACLE_TYPE_CLOB #}
+  fromEnum OracleTypeNclob = {#const DPI_ORACLE_TYPE_NCLOB #}
+  fromEnum OracleTypeBlob = {#const DPI_ORACLE_TYPE_BLOB #}
+  fromEnum OracleTypeBfile = {#const DPI_ORACLE_TYPE_BFILE #}
+  fromEnum OracleTypeStmt = {#const DPI_ORACLE_TYPE_STMT #}
+  fromEnum OracleTypeBoolean = {#const DPI_ORACLE_TYPE_BOOLEAN #}
+  fromEnum OracleTypeObject = {#const DPI_ORACLE_TYPE_OBJECT #}
+  fromEnum OracleTypeLongVarchar = {#const DPI_ORACLE_TYPE_LONG_VARCHAR #}
+  fromEnum OracleTypeLongRaw = {#const DPI_ORACLE_TYPE_LONG_RAW #}
+  fromEnum OracleTypeNativeUint = {#const DPI_ORACLE_TYPE_NATIVE_UINT #}
+#else
 {#enum OracleTypeNum       as ^ {underscoreToCase} deriving (Eq, Show) #}
+#endif
+
+#if DPI_MAJOR_VERSION >= 3
+data PoolCloseMode
+  = ModePoolCloseDefault | ModePoolCloseForce
+  deriving(Eq, Show)
+
+instance Enum PoolCloseMode where
+  toEnum {#const DPI_MODE_POOL_CLOSE_DEFAULT #} = ModePoolCloseDefault
+  toEnum {#const DPI_MODE_POOL_CLOSE_FORCE #} = ModePoolCloseForce
+  toEnum _ = error "Value invalid"
+  fromEnum ModePoolCloseDefault = {#const DPI_MODE_POOL_CLOSE_DEFAULT #}
+  fromEnum ModePoolCloseForce = {#const DPI_MODE_POOL_CLOSE_FORCE #}
+#else
 {#enum PoolCloseMode       as ^ {underscoreToCase} deriving (Eq, Show) #}
+#endif
+
+#if DPI_MAJOR_VERSION >= 3
+data PoolGetMode
+  = ModePoolGetWait | ModePoolGetNowait | ModePoolGetForceget | ModePoolGetTimedwait
+  deriving(Eq, Show)
+
+instance Enum PoolGetMode where
+  toEnum {#const DPI_MODE_POOL_GET_WAIT #} = ModePoolGetWait
+  toEnum {#const DPI_MODE_POOL_GET_NOWAIT #} = ModePoolGetNowait
+  toEnum {#const DPI_MODE_POOL_GET_FORCEGET #} = ModePoolGetForceget
+  toEnum {#const DPI_MODE_POOL_GET_TIMEDWAIT #} = ModePoolGetTimedwait
+  toEnum _ = error "Value invalid"
+  fromEnum ModePoolGetWait = {#const DPI_MODE_POOL_GET_WAIT #}
+  fromEnum ModePoolGetNowait = {#const DPI_MODE_POOL_GET_NOWAIT #}
+  fromEnum ModePoolGetForceget = {#const DPI_MODE_POOL_GET_FORCEGET #}
+  fromEnum ModePoolGetTimedwait = {#const DPI_MODE_POOL_GET_TIMEDWAIT #}
+#else
 {#enum PoolGetMode         as ^ {underscoreToCase} deriving (Eq, Show) #}
+#endif
+
+#if DPI_MAJOR_VERSION >= 3
+data Purity
+  = PurityDefault | PurityNew | PuritySelf
+  deriving(Eq, Show)
+
+instance Enum Purity where
+  toEnum {#const DPI_PURITY_DEFAULT #} = PurityDefault
+  toEnum {#const DPI_PURITY_NEW #} = PurityNew
+  toEnum {#const DPI_PURITY_SELF #} = PuritySelf
+  toEnum _ = error "Value invalid"
+  fromEnum PurityDefault = {#const DPI_PURITY_DEFAULT #}
+  fromEnum PurityNew = {#const DPI_PURITY_NEW #}
+  fromEnum PuritySelf = {#const DPI_PURITY_SELF #}
+#else
 {#enum Purity              as ^ {underscoreToCase} deriving (Eq, Show) #}
+#endif
+
+#if DPI_MAJOR_VERSION >= 3
+data ShutdownMode
+  = ModeShutdownDefault | ModeShutdownTransactional | ModeShutdownTransactionalLocal
+  | ModeShutdownImmediate | ModeShutdownAbort | ModeShutdownFinal
+  deriving(Eq, Show)
+
+instance Enum ShutdownMode where
+  toEnum {#const DPI_MODE_SHUTDOWN_DEFAULT #} = ModeShutdownDefault
+  toEnum {#const DPI_MODE_SHUTDOWN_TRANSACTIONAL #} = ModeShutdownTransactional
+  toEnum {#const DPI_MODE_SHUTDOWN_TRANSACTIONAL_LOCAL #} = ModeShutdownTransactionalLocal
+  toEnum {#const DPI_MODE_SHUTDOWN_IMMEDIATE #} = ModeShutdownImmediate
+  toEnum {#const DPI_MODE_SHUTDOWN_ABORT #} = ModeShutdownAbort
+  toEnum {#const DPI_MODE_SHUTDOWN_FINAL #} = ModeShutdownFinal
+  toEnum _ = error "Value invalid"
+  fromEnum ModeShutdownDefault = {#const DPI_MODE_SHUTDOWN_DEFAULT #}
+  fromEnum ModeShutdownTransactional = {#const DPI_MODE_SHUTDOWN_TRANSACTIONAL #}
+  fromEnum ModeShutdownTransactionalLocal = {#const DPI_MODE_SHUTDOWN_TRANSACTIONAL_LOCAL #}
+  fromEnum ModeShutdownImmediate = {#const DPI_MODE_SHUTDOWN_IMMEDIATE #}
+  fromEnum ModeShutdownAbort = {#const DPI_MODE_SHUTDOWN_ABORT #}
+  fromEnum ModeShutdownFinal = {#const DPI_MODE_SHUTDOWN_FINAL #}
+#else
 {#enum ShutdownMode        as ^ {underscoreToCase} deriving (Eq, Show) #}
+#endif
+
+#if DPI_MAJOR_VERSION >= 3
+data StartupMode
+  = ModeStartupDefault | ModeStartupForce | ModeStartupRestrict
+  deriving(Eq, Show)
+
+instance Enum StartupMode where
+  toEnum {#const DPI_MODE_STARTUP_DEFAULT #} = ModeStartupDefault
+  toEnum {#const DPI_MODE_STARTUP_FORCE #} = ModeStartupForce
+  toEnum {#const DPI_MODE_STARTUP_RESTRICT #} = ModeStartupRestrict
+  toEnum _ = error "Value invalid"
+  fromEnum ModeStartupDefault = {#const DPI_MODE_STARTUP_DEFAULT #}
+  fromEnum ModeStartupForce = {#const DPI_MODE_STARTUP_FORCE #}
+  fromEnum ModeStartupRestrict = {#const DPI_MODE_STARTUP_RESTRICT #}
+#else
 {#enum StartupMode         as ^ {underscoreToCase} deriving (Eq, Show) #}
+#endif
+
+#if DPI_MAJOR_VERSION >= 3
+data StatementType
+  = StmtTypeUnknown | StmtTypeSelect | StmtTypeUpdate | StmtTypeDelete
+  | StmtTypeInsert | StmtTypeCreate | StmtTypeDrop | StmtTypeAlter
+  | StmtTypeBegin | StmtTypeDeclare | StmtTypeCall | StmtTypeExplainPlan
+  | StmtTypeMerge | StmtTypeRollback | StmtTypeCommit
+  deriving(Eq, Show)
+
+instance Enum StatementType where
+  toEnum {#const DPI_STMT_TYPE_UNKNOWN #} = StmtTypeUnknown
+  toEnum {#const DPI_STMT_TYPE_SELECT #} = StmtTypeSelect
+  toEnum {#const DPI_STMT_TYPE_UPDATE #} = StmtTypeUpdate
+  toEnum {#const DPI_STMT_TYPE_DELETE #} = StmtTypeDelete
+  toEnum {#const DPI_STMT_TYPE_INSERT #} = StmtTypeInsert
+  toEnum {#const DPI_STMT_TYPE_CREATE #} = StmtTypeCreate
+  toEnum {#const DPI_STMT_TYPE_DROP #} = StmtTypeDrop
+  toEnum {#const DPI_STMT_TYPE_ALTER #} = StmtTypeAlter
+  toEnum {#const DPI_STMT_TYPE_BEGIN #} = StmtTypeBegin
+  toEnum {#const DPI_STMT_TYPE_DECLARE #} = StmtTypeDeclare
+  toEnum {#const DPI_STMT_TYPE_CALL #} = StmtTypeCall
+  toEnum {#const DPI_STMT_TYPE_EXPLAIN_PLAN #} = StmtTypeExplainPlan
+  toEnum {#const DPI_STMT_TYPE_MERGE #} = StmtTypeMerge
+  toEnum {#const DPI_STMT_TYPE_ROLLBACK #} = StmtTypeRollback
+  toEnum {#const DPI_STMT_TYPE_COMMIT #} = StmtTypeCommit
+  toEnum _ = error "Value invalid"
+  fromEnum StmtTypeUnknown = {#const DPI_STMT_TYPE_UNKNOWN #}
+  fromEnum StmtTypeSelect = {#const DPI_STMT_TYPE_SELECT #}
+  fromEnum StmtTypeUpdate = {#const DPI_STMT_TYPE_UPDATE #}
+  fromEnum StmtTypeDelete = {#const DPI_STMT_TYPE_DELETE #}
+  fromEnum StmtTypeInsert = {#const DPI_STMT_TYPE_INSERT #}
+  fromEnum StmtTypeCreate = {#const DPI_STMT_TYPE_CREATE #}
+  fromEnum StmtTypeDrop = {#const DPI_STMT_TYPE_DROP #}
+  fromEnum StmtTypeAlter = {#const DPI_STMT_TYPE_ALTER #}
+  fromEnum StmtTypeBegin = {#const DPI_STMT_TYPE_BEGIN #}
+  fromEnum StmtTypeDeclare = {#const DPI_STMT_TYPE_DECLARE #}
+  fromEnum StmtTypeCall = {#const DPI_STMT_TYPE_CALL #}
+  fromEnum StmtTypeExplainPlan = {#const DPI_STMT_TYPE_EXPLAIN_PLAN #}
+  fromEnum StmtTypeMerge = {#const DPI_STMT_TYPE_MERGE #}
+  fromEnum StmtTypeRollback = {#const DPI_STMT_TYPE_ROLLBACK #}
+  fromEnum StmtTypeCommit = {#const DPI_STMT_TYPE_COMMIT #}
+#else
 {#enum StatementType       as ^ {underscoreToCase} deriving (Eq, Show) #}
-{#enum SubscrNamespace     as ^ {underscoreToCase} deriving (Eq, Show) #}
-{#enum SubscrProtocol      as ^ {underscoreToCase} deriving (Eq, Show) #}
-{#enum SubscrQOS           as ^ {underscoreToCase} deriving (Eq, Show) #}
-{#enum Visibility          as ^ {underscoreToCase} deriving (Eq, Show) #}
+#endif
 
 #if DPI_MAJOR_VERSION >= 2 && DPI_MINOR_VERSION >= 4
 data SubscrGroupingClass = SubscrGroupingClassTime deriving (Eq, Show)
@@ -56,8 +561,8 @@ instance Enum SubscrGroupingClass where
   toEnum _ = error "Value invalid"
   fromEnum _ = {#const DPI_SUBSCR_GROUPING_CLASS_TIME #}
 
-data SubscrGroupingType 
-  = SubscrGroupingTypeSummary 
+data SubscrGroupingType
+  = SubscrGroupingTypeSummary
   | SubscrGroupingTypeLast
   deriving (Eq, Show)
 
@@ -69,7 +574,77 @@ instance Enum SubscrGroupingType where
   fromEnum SubscrGroupingTypeLast    = {#const DPI_SUBSCR_GROUPING_TYPE_LAST    #}
 #endif
 
--- Handler 
+#if DPI_MAJOR_VERSION >= 3
+data SubscrNamespace
+  = SubscrNamespaceAq | SubscrNamespaceDbchange
+  deriving(Eq, Show)
+
+instance Enum SubscrNamespace where
+  toEnum {#const DPI_SUBSCR_NAMESPACE_AQ #} = SubscrNamespaceAq
+  toEnum {#const DPI_SUBSCR_NAMESPACE_DBCHANGE #} = SubscrNamespaceDbchange
+  toEnum _ = error "Value invalid"
+  fromEnum SubscrNamespaceAq = {#const DPI_SUBSCR_NAMESPACE_AQ #}
+  fromEnum SubscrNamespaceDbchange = {#const DPI_SUBSCR_NAMESPACE_DBCHANGE #}
+#else
+{#enum SubscrNamespace     as ^ {underscoreToCase} deriving (Eq, Show) #}
+#endif
+
+#if DPI_MAJOR_VERSION >= 3
+data SubscrProtocol
+  = SubscrProtoCallback | SubscrProtoMail | SubscrProtoPlsql | SubscrProtoHttp
+  deriving(Eq, Show)
+
+instance Enum SubscrProtocol where
+  toEnum {#const DPI_SUBSCR_PROTO_CALLBACK #} = SubscrProtoCallback
+  toEnum {#const DPI_SUBSCR_PROTO_MAIL #} = SubscrProtoMail
+  toEnum {#const DPI_SUBSCR_PROTO_PLSQL #} = SubscrProtoPlsql
+  toEnum {#const DPI_SUBSCR_PROTO_HTTP #} = SubscrProtoHttp
+  toEnum _ = error "Value invalid"
+  fromEnum SubscrProtoCallback = {#const DPI_SUBSCR_PROTO_CALLBACK #}
+  fromEnum SubscrProtoMail = {#const DPI_SUBSCR_PROTO_MAIL #}
+  fromEnum SubscrProtoPlsql = {#const DPI_SUBSCR_PROTO_PLSQL #}
+  fromEnum SubscrProtoHttp = {#const DPI_SUBSCR_PROTO_HTTP #}
+#else
+{#enum SubscrProtocol      as ^ {underscoreToCase} deriving (Eq, Show) #}
+#endif
+
+#if DPI_MAJOR_VERSION >= 3
+data SubscrQOS
+  = SubscrQosReliable | SubscrQosDeregNfy | SubscrQosRowids
+  | SubscrQosQuery | SubscrQosBestEffort
+  deriving(Eq, Show)
+
+instance Enum SubscrQOS where
+  toEnum {#const DPI_SUBSCR_QOS_RELIABLE #} = SubscrQosReliable
+  toEnum {#const DPI_SUBSCR_QOS_DEREG_NFY #} = SubscrQosDeregNfy
+  toEnum {#const DPI_SUBSCR_QOS_ROWIDS #} = SubscrQosRowids
+  toEnum {#const DPI_SUBSCR_QOS_QUERY #} = SubscrQosQuery
+  toEnum {#const DPI_SUBSCR_QOS_BEST_EFFORT #} = SubscrQosBestEffort
+  toEnum _ = error "Value invalid"
+  fromEnum SubscrQosReliable = {#const DPI_SUBSCR_QOS_RELIABLE #}
+  fromEnum SubscrQosDeregNfy = {#const DPI_SUBSCR_QOS_DEREG_NFY #}
+  fromEnum SubscrQosRowids = {#const DPI_SUBSCR_QOS_ROWIDS #}
+  fromEnum SubscrQosQuery = {#const DPI_SUBSCR_QOS_QUERY #}
+  fromEnum SubscrQosBestEffort = {#const DPI_SUBSCR_QOS_BEST_EFFORT #}
+#else
+{#enum SubscrQOS           as ^ {underscoreToCase} deriving (Eq, Show) #}
+#endif
+
+#if DPI_MAJOR_VERSION >= 3
+data Visibility = VisibilityImmediate | VisibilityOnCommit
+                deriving(Eq, Show)
+
+instance Enum Visibility where
+  toEnum {#const DPI_VISIBILITY_IMMEDIATE #} = VisibilityImmediate
+  toEnum {#const DPI_VISIBILITY_ON_COMMIT #} = VisibilityOnCommit
+  toEnum _ = error "Value invalid"
+  fromEnum VisibilityImmediate = {#const DPI_VISIBILITY_IMMEDIATE #}
+  fromEnum VisibilityOnCommit = {#const DPI_VISIBILITY_ON_COMMIT #}
+#else
+{#enum Visibility          as ^ {underscoreToCase} deriving (Eq, Show) #}
+#endif
+
+-- Handler
 {#pointer *Conn       as DPI_Conn       foreign newtype #}
 {#pointer *Pool       as DPI_Pool       foreign newtype #}
 {#pointer *Stmt       as DPI_Stmt       foreign newtype #}
@@ -86,7 +661,7 @@ instance Enum SubscrGroupingType where
 
 {#pointer *Context    as DPI_Context    foreign newtype #}
 
-type HasCxtPtr a   = (PtrContext, Ptr a) 
+type HasCxtPtr a   = (PtrContext, Ptr a)
 type PtrConn       = HasCxtPtr DPI_Conn
 type PtrPool       = HasCxtPtr DPI_Pool
 type PtrStmt       = HasCxtPtr DPI_Stmt
@@ -250,7 +825,7 @@ instance Storable Data_CommonCreateParams where
   sizeOf    _ = {#sizeof  CommonCreateParams #}
   alignment _ = {#alignof CommonCreateParams #}
   poke    p Data_CommonCreateParams{..} = B.unsafeUseAsCString encoding $ \pe -> B.unsafeUseAsCString nencoding $ \pn -> do
-    let (e,elen) = edition   
+    let (e,elen) = edition
         (d,dlen) = driverName
     {#set CommonCreateParams -> createMode       #} p (fe createMode)
     {#set CommonCreateParams -> encoding         #} p pe
@@ -740,7 +1315,7 @@ instance Storable Data_PoolCreateParams where
   sizeOf    _ = {#sizeof  PoolCreateParams #}
   alignment _ = {#alignof PoolCreateParams #}
   poke      p Data_PoolCreateParams{..} = do
-    let (e,elen) = outPoolName   
+    let (e,elen) = outPoolName
     {#set PoolCreateParams -> minSessions       #} p minSessions
     {#set PoolCreateParams -> maxSessions       #} p maxSessions
     {#set PoolCreateParams -> sessionIncrement  #} p sessionIncrement
@@ -1043,7 +1618,7 @@ instance Storable Data_VersionInfo where
     fullVersionNum <- {#get VersionInfo -> fullVersionNum #} p
     return Data_VersionInfo {..}
 
--- Context 
+-- Context
 {-# INLINE libContextCreate                 #-}
 {-# INLINE libContextDestroy                #-}
 {-# INLINE libContextGetClientVersion       #-}
@@ -1149,12 +1724,12 @@ libConnStartupDatabase     = {#call Conn_startupDatabase     #}
 #if DPI_MAJOR_VERSION >= 2 && DPI_MINOR_VERSION >= 4
 libConnSubscribe           = {#call Conn_subscribe           #}
 libConnUnsubscribe         = {#call Conn_unsubscribe         #}
-#else 
+#else
 libConnSubscribe           = error "No implement until 2.4.0"
 libConnUnsubscribe         = error "No implement until 2.4.0"
 #endif
 
--- Data 
+-- Data
 {-# INLINE libDataGetDouble     #-}
 {-# INLINE libDataGetBytes      #-}
 {-# INLINE libDataGetIntervalDS #-}
@@ -1433,7 +2008,7 @@ libPoolSetTimeout            = {#call Pool_setTimeout            #}
 #if DPI_MAJOR_VERSION >= 2 && DPI_MINOR_VERSION >= 4
 libPoolGetWaitTimeout        = {#call Pool_getWaitTimeout       #}
 libPoolSetWaitTimeout        = {#call Pool_setWaitTimeout       #}
-#else 
+#else
 libPoolGetWaitTimeout        = error "No implement until 2.4.0"
 libPoolSetWaitTimeout        = error "No implement until 2.4.0"
 #endif


### PR DESCRIPTION
odpic 3.0.0 introduced some breaking changes.

From their [changelog](https://github.com/oracle/odpi/blob/master/doc/src/releasenotes.rst):

```
Version 3.0.0 (September 13, 2018)
----------------------------------

#)  Added support for Oracle Client 18 libraries.
#)  Added support for SODA (as preview). See
    :ref:`SODA Database<dpiSodaDbFunctions>`,
    :ref:`SODA Collection<dpiSodaCollFunctions>` and
    :ref:`SODA Document<dpiSodaDocFunctions>` for more information.
#)  Added support for call timeouts available in Oracle Client 18.1 and higher.
    See functions :func:`dpiConn_setCallTimeout()` and
    :func:`dpiConn_getCallTimeout()`.
#)  Added support for setting a LOB attribute of an object with string/bytes
    using the function :func:`dpiObject_setAttributeValue()`.
#)  Added support for the packed decimal type used by object attributes with
    historical types DECIMAL and NUMERIC
    (`cx_Oracle issue 212
    <https://github.com/oracle/python-cx_Oracle/issues/212>`__).
#)  On Windows, first attempt to load oci.dll from the same directory as the
    module that contains ODPI-C.
#)  SQL Objects that are created or fetched from the database are now tracked
    and marked unusable when a connection is closed. This was done in order to
    avoid a segfault in some circumstances.
#)  Improved support for closing pools by ensuring that once a pool has closed,
    further attempts to use connections acquired from that pool will fail with
    error "DPI-1010: not connected".
#)  Re-enabled pool pinging functionality for Oracle Client 12.2 and higher
    to handle classes of connection errors such as resource profile limits.
#)  Improved error messages when the Oracle Client or Oracle Database need to
    be at a minimum version in order to support a particular feature.
#)  Use plain integers instead of enumerations in order to simplify code and
    reduce the requirement for casts. Typedefs have been included so that code
    does not need to be changed.
#)  Eliminated potential buffer overrun
    (`issue 69 <https://github.com/oracle/odpi/issues/69>`__).
#)  In the Makefile for non-Windows platforms, the version information for
    ODPI-C is acquired directly from include/dpi.h as suggested
    (`issue 66 <https://github.com/oracle/odpi/issues/66>`__).
#)  Removed function dpiConn_newSubscription(). Use function
    :func:`dpiConn_subscribe()` instead.
#)  Removed function dpiLob_flushBuffer(). This function never worked anyway.
#)  Removed function dpiSubscr_close(). Use function
    :func:`dpiConn_unsubscribe()` instead.
#)  Removed function dpiVar_getData(). Use function
    :func:`dpiVar_getReturnedData()` instead.
#)  Added additional test cases.
#)  Improved documentation.
```

So far, I did the following:

 - Followed the enum -> plain integer changes, which unfortunately is quite verbose, as [c2hs doesn't support #define enums yet](https://github.com/haskell/c2hs/blob/7e45dc8497bf38054f00e9e2c46f5a525a299273/TODO#L221)
 - used the successors of some deprecated and removed methods.
  I'm not sure why we expose them like this in first place, and whether the way this is done now is the way it should be.
 - remove the broken `flushLob` that upstream removed too. It never really worked anyhow.


I'm currently stuck at some weird CInt / CUInt problems, and lack the haskell-foo to do that on my own:

```
building
Preprocessing library for odpic-raw-0.3.0..
Building library for odpic-raw-0.3.0..
[1 of 6] Compiling Database.Dpi.Prelude ( src/Database/Dpi/Prelude.hs, dist/build/Database/Dpi/Prelude.o )
[2 of 6] Compiling Database.Dpi.Internal ( dist/build/Database/Dpi/Internal.hs, dist/build/Database/Dpi/Internal.o )

src/Database/Dpi/Internal.chs:1484:12: error:
    • Couldn't match expected type ‘CInt’ with actual type ‘CUInt’
    • In the ‘operations’ field of a record
      In the first argument of ‘return’, namely
        ‘Data_SubscrCreateParams {..}’
      In a stmt of a 'do' block: return Data_SubscrCreateParams {..}
     |
1484 | #if DPI_MAJOR_VERSION >= 2 && DPI_MINOR_VERSION >= 4
     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: keeping build directory '/tmp/nix-build-odpic-raw-0.3.0.drv-16'
builder for '/nix/store/v0w2w6vbvfw83l84mj81gy9zszcaxkpw-odpic-raw-0.3.0.drv' failed with exit code 1
error: build of '/nix/store/v0w2w6vbvfw83l84mj81gy9zszcaxkpw-odpic-raw-0.3.0.drv' failed
```

I'd appreciate if somebody could take it over from here.

fixes #13