### PR TITLE
bug: fix bug where queryByPage would return rows in the opposite of the intended order

### DIFF
--- a/src/Database/Dpi/Sql.hs
+++ b/src/Database/Dpi/Sql.hs
@@ -88,4 +88,4 @@ queryAsRes conn sql ps = do
 queryByPage :: FromDataFields a => PtrConn -> SQL -> [SqlParam] -> Page -> IO [a]
 queryByPage conn sql ps (offset,limit) = do
   let sql' = sql <> " OFFSET " <> show offset <> " ROWS FETCH NEXT " <> show limit <> " ROWS ONLY"
-  with (queryAsRes conn sql' ps) (\a -> runConduit $ a .| CL.fold (flip (:)) [])
+  with (queryAsRes conn sql' ps) (\conduit -> runConduit $ conduit .| CL.consume)


### PR DESCRIPTION
`queryByPage` does not properly respect `ORDER BY` clauses, and will in fact rows in the opposite of the intended order.

E.g. if the query is `SELECT ... FROM ... ORDER BY ... ASC`, a descending order is observed.

I've amended the `conduit` code in `queryByPage` to use `consume` to consume the conduit and directly translate into a list in a way that preserves the ordering of the rows returned.