### PR TITLE
fix(dpi): release connection after closing

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,9 @@
 # Changelog
 
-Recent changes include:
+## 2022-04-08:
+- calling `releaseConnection` in `withConnectionFromPool` to eliminate a memory leak
+
+## 2021-12-16:
 - replacing `malloc` with `calloc` to workaround a deficiency in the `Storable` instance for `Data` (where `isNull` was not appropriately being set to `0`)
 - moving calls to `malloc`/`calloc` to sites where they could be accompanied by appropriate calls to `free` to avoid space leaks
 - amending `queryByPage` to return records in the appropriate order

--- a/src/Database/Dpi.hs
+++ b/src/Database/Dpi.hs
@@ -520,7 +520,7 @@ withPoolConnection p = bracket (acquiredConnection p) releaseConnection
 --   Compare with 'withPoolConnection', which calls 'releaseConnection' after the action.
 {-# INLINE withConnectionFromPool #-}
 withConnectionFromPool :: PtrPool -> (PtrConn -> IO a) -> IO a
-withConnectionFromPool p = bracket (acquiredConnection p) (closeConnection ModeConnCloseDefault)
+withConnectionFromPool p = bracket (acquiredConnection p) (\c -> closeConnection ModeConnCloseDefault c `finally` releaseConnection c)
 
 -- | Returns the number of sessions in the pool that are busy.
 {-# INLINE getPoolBusyCount #-}


### PR DESCRIPTION
https://github.com/oracle/odpi/issues/87#issuecomment-458213845
indicates that a connection must always be released, even if it has been
closed.